### PR TITLE
Add vignette for how to classify the proportion of code in a document (and across multiple documents)

### DIFF
--- a/vignettes/calculating-proportion-of-code.Rmd
+++ b/vignettes/calculating-proportion-of-code.Rmd
@@ -14,10 +14,6 @@ knitr::opts_chunk$set(
 )
 ```
 
-```{r setup}
-library(tidycode)
-```
-
 ## Introduction
 
 tidycode can be used to easily classify the lines of code in an R file (e.g., as data cleaning, setup, etc.).
@@ -59,7 +55,7 @@ classified_code <- unnested_expressions %>%
 Then, we will create a simple function that takes the classified code and calculates the proportion of the lines of code in each file that is classified into different categories:
 
 ```{r}
-calc_proportion_of_file <- function(d) {
+calc_proportion_file <- function(d) {
   d %>% 
     count(file, classification) %>% 
     group_by(file) %>% 
@@ -72,28 +68,81 @@ calc_proportion_of_file <- function(d) {
 It is easy to use the function on our classified code:
 
 ```{r}
-proportion_of_file <- calc_proportion_of_file(classified_code)
+proportion_of_file <- calc_proportion_file(classified_code)
 
 proportion_of_file
 ```
 
-## Visualization
+## Visualizing classified code on a per-file basis
 
 We can also easily visualize the results:
 
 ```{r}
-proportion_of_file %>% 
-  ggplot(aes(x = reorder(classification, prop), y = prop, fill = file))+
+proportion_of_file %>%
+  ggplot()+
   coord_flip()+
-  geom_bar(stat="identity")+
-  geom_text(aes(x = reorder(classification, prop), y = prop, group = file, label = paste0(round(prop*100, digits=0), "%")), position = position_stack(), hjust=1)+
-  geom_text(
-    aes(label = paste0(round(stat(y)*100, digits=0), "%"), group = classification), 
-    stat = 'summary', fun.y = sum, hjust=-.5
+  geom_bar(aes(x=0, y=prop, fill=reorder(classification, prop)), stat="identity", size=1)+
+  scale_y_continuous(labels=scales::percent_format())+
+  facet_wrap(~file, ncol=1)+
+  labs(
+    title = "Proportion of Code by File",
+    y = "Proportion of Code",
+    fill = "Classification"
   )+
-  scale_y_continuous(labels=scales::percent_format(), limits=c(0,1.1), breaks=c(0, .2, .4, .6, .8, 1))+
-  guides(fill=guide_legend(ncol=1))+
-  xlab("Type of Code")+
-  ylab("Proportion of Code")+
-  theme(legend.position = "bottom")
+  theme(
+    axis.text.y = element_blank(),
+    axis.ticks.y = element_blank(),
+    axis.title.y = element_blank(),
+    strip.text = element_text(hjust=0),
+    panel.background = element_blank(),
+    strip.background = element_blank(),
+    panel.grid.major.x = element_line(color="grey80")
+  )
+```
+
+This can become quite a large viz if there are very many files; thus, this approach may be more useful when trying to visualize code on on a per-file basis for a relatively small (perhaps 10-15 or fewer) files.
+
+Next, we show how this approach may be scaled up to a larger number of files by visualizing the proportion of code classified across many files.
+
+## Visualizing classified code across files
+
+First, we'll create a function that is an analog to `calc_proportion_file()`, but for calculating the mean proportion across many files:
+
+```{r}
+calc_proportion_overall <- function(d) {
+  d %>% group_by(classification) %>%
+    count() %>% 
+    ungroup() %>% 
+    mutate(
+      prop = prop.table(n)
+    )
+}
+```
+
+We can use this in the same way as `calc_proportion_file()`, passing `classified_code` as the sole argument:
+
+```{r}
+proportion_overall <- calc_proportion_overall(classified_code)
+proportion_overall
+```
+
+These results can be visualized as follows:
+
+```{r}
+proportion_overall %>%
+  ggplot()+
+  coord_flip()+
+  geom_bar(aes(x=reorder(classification, prop), y=1), stat="identity", fill="grey80")+
+  geom_bar(aes(x=reorder(classification, prop), y=prop, fill=prop), stat="identity")+
+  geom_text(aes(x=reorder(classification, prop), y=prop, label=paste0(round(prop*100, digits=0), "%"), hjust=-.5))+
+  scale_y_continuous(labels=scales::percent_format())+
+  labs(
+    title = "Overall Proportion of Code",
+    y = "Proportion of Code",
+    x = "Classification"
+  )+
+  theme(
+    panel.background = element_blank(),
+    legend.position = "none"
+  )
 ```

--- a/vignettes/calculating-proportion-of-code.Rmd
+++ b/vignettes/calculating-proportion-of-code.Rmd
@@ -24,7 +24,7 @@ This vignette shows how tidycode can easily be used to calculate the proportion 
 
 ## Loading and setting up
 
-We will frist load the tidyverse and tidycode packages, and then use the tidycode function `read_rfiles()` to read two example files:
+We will frist load the tidyverse and tidycode packages and then use the tidycode function `read_rfiles()` to read the two example files (built-in to tidycode):
 
 ```{r, message = FALSE}
 library(tidyverse)
@@ -39,7 +39,7 @@ two_rfiles <- read_rfiles(
 
 ## Classify the lines of code in the R files
 
-Next, we can classify the lines of code in the two rfiles saved to the object `two_rfiles`:
+Next, we can classify the lines of code in the two rfiles saved to the object `two_rfiles`, using the `unnest_calls()` and subsequent functions as described in the [tidycode vignette](tidycode.html):
 
 ```{r}
 unnested_expressions <- unnest_calls(two_rfiles, expr)
@@ -54,7 +54,7 @@ classified_code <- unnested_expressions %>%
 
 ## Creating a function
 
-Then, we will create a simple function that takes the classified code and calculates the proportion of the lines of code in each file that is classified into different categories:
+Then, we will create a simple function that a) takes the classified code and then b) calculates the proportion of the lines of code in each file that is classified into different categories:
 
 ```{r}
 calc_proportion_file <- function(d) {
@@ -67,7 +67,7 @@ calc_proportion_file <- function(d) {
 
 ## Using the function
 
-It is easy to use the function on our classified code:
+It is easy to use the function on our classified code; just pass the classified code to it.:
 
 ```{r}
 proportion_of_file <- calc_proportion_file(classified_code)
@@ -102,9 +102,11 @@ proportion_of_file %>%
   )
 ```
 
-This can become quite a large viz if there are very many files; thus, this approach may be more useful when trying to visualize code on on a per-file basis for a relatively small (perhaps 10-15 or fewer) files.
+This can become quite a large visualization if there are very many files. 
 
-Next, we show how this approach may be scaled up to a larger number of files by visualizing the proportion of code classified across many files.
+Thus, this approach may be more useful when trying to visualize code on on a per-file basis for a relatively small (perhaps 10-15 or fewer) files.
+
+Another approach can be scaled up to a larger number of files, as is described next.
 
 ## Visualizing classified code across files
 

--- a/vignettes/calculating-proportion-of-code.Rmd
+++ b/vignettes/calculating-proportion-of-code.Rmd
@@ -24,7 +24,7 @@ This vignette shows how tidycode can easily be used to calculate the proportion 
 
 We will frist load the tidyverse and tidycode packages, and then use the tidycode function `read_rfiles()` to read two example files:
 
-```{r}
+```{r, message = FALSE}
 library(tidyverse)
 library(tidycode)
 

--- a/vignettes/calculating-proportion-of-code.Rmd
+++ b/vignettes/calculating-proportion-of-code.Rmd
@@ -10,7 +10,9 @@ vignette: >
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  fig.width = 7,
+  fig.height = 7
 )
 ```
 

--- a/vignettes/calculating-proportion-of-code.Rmd
+++ b/vignettes/calculating-proportion-of-code.Rmd
@@ -83,7 +83,17 @@ We can also easily visualize the results:
 
 ```{r}
 proportion_of_file %>% 
-  ggplot(aes(x = classification, y = prop, color = file)) +
-  geom_point() +
+  ggplot(aes(x = reorder(classification, prop), y = prop, fill = file))+
+  coord_flip()+
+  geom_bar(stat="identity")+
+  geom_text(aes(x = reorder(classification, prop), y = prop, group = file, label = paste0(round(prop*100, digits=0), "%")), position = position_stack(), hjust=1)+
+  geom_text(
+    aes(label = paste0(round(stat(y)*100, digits=0), "%"), group = classification), 
+    stat = 'summary', fun.y = sum, hjust=-.5
+  )+
+  scale_y_continuous(labels=scales::percent_format(), limits=c(0,1.1), breaks=c(0, .2, .4, .6, .8, 1))+
+  guides(fill=guide_legend(ncol=1))+
+  xlab("Type of Code")+
+  ylab("Proportion of Code")+
   theme(legend.position = "bottom")
 ```

--- a/vignettes/calculating-proportion-of-code.Rmd
+++ b/vignettes/calculating-proportion-of-code.Rmd
@@ -1,0 +1,89 @@
+---
+title: "Calculating the proportion of code classified in an R file"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{calculating-proportion-of-code}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+```{r setup}
+library(tidycode)
+```
+
+## Introduction
+
+tidycode can be used to easily classify the lines of code in an R file (e.g., as data cleaning, setup, etc.).
+
+This vignette shows how tidycode can easily be used to calculate the proportion of a total R file classified to different categories?
+
+## Loading and setting up
+
+We will frist load the tidyverse and tidycode packages, and then use the tidycode function `read_rfiles()` to read two example files:
+
+```{r}
+library(tidyverse)
+library(tidycode)
+
+two_rfiles <- read_rfiles(
+  tidycode_example("example_plot.R"),
+  tidycode_example("example_analysis.R")
+)
+
+```
+
+## Classify the lines of code in the R files
+
+Next, we can classify the lines of code in the two rfiles saved to the object `two_rfiles`:
+
+```{r}
+unnested_expressions <- unnest_calls(two_rfiles, expr)
+
+classified_code <- unnested_expressions %>%
+  dplyr::inner_join(
+    get_classifications("crowdsource", include_duplicates = FALSE)
+  ) %>%
+  dplyr::anti_join(get_stopfuncs()) %>%
+  dplyr::select(file, func, classification)
+```
+
+## Creating a function
+
+Then, we will create a simple function that takes the classified code and calculates the proportion of the lines of code in each file that is classified into different categories:
+
+```{r}
+calc_proportion_of_file <- function(d) {
+  d %>% 
+    count(file, classification) %>% 
+    group_by(file) %>% 
+    mutate(prop = n / sum(n))
+}
+```
+
+## Using the function
+
+It is easy to use the function on our classified code:
+
+```{r}
+proportion_of_file <- calc_proportion_of_file(classified_code)
+
+proportion_of_file
+```
+
+## Visualization
+
+We can also easily visualize the results:
+
+```{r}
+proportion_of_file %>% 
+  ggplot(aes(x = classification, y = prop, color = file)) +
+  geom_point() +
+  theme(legend.position = "bottom")
+```


### PR DESCRIPTION
Per #5, this is a vignette for how to classify the proportion of code in a document (and across multiple documents). Please let us know what to change! Thank you!